### PR TITLE
Updated 'menu' subtype in 'matrix' type

### DIFF
--- a/R/fetch_survey.R
+++ b/R/fetch_survey.R
@@ -51,6 +51,17 @@ fetch_survey_obj <- function(id,
             answers[[row$id]] <- trimws(row$text)
           }      
         }
+        if ("cols" %in% names(question$answers)) {
+           for (col in question$answers$cols) {
+                  answers[[col$id]] <- trimws(col$text)
+                  if ("choices" %in% names(col)){
+                        for(choice in col$choices){
+                              answers[[choice$id]] <- trimws(choice$text)
+                              choices[[question$id]] <- c(choices[[question$id]], answers[[choice$id]])
+                        }
+                  }
+            }
+         }
         if ("choices" %in% names(question$answers)) {
           for (choice in question$answers$choices) {
             answers[[choice$id]] <- trimws(choice$text)

--- a/R/parse_survey.R
+++ b/R/parse_survey.R
@@ -47,8 +47,6 @@ parse_survey <- function(surv_obj,
   
   surv_obj$col_fill <- col_fill
   
-  surv_obj$col_fill <- col_fill
-  
   labels <- list()
   recordsList <- pbapply::pblapply(1:length(respondents), function(r) {
     response <- respondents[[r]]
@@ -74,6 +72,9 @@ parse_survey <- function(surv_obj,
           out <- process_single_choice(surv_obj, question)
         }
         if (family == "open_ended") {
+          out <- process_open_ended(surv_obj, question)
+        }
+        if (family == "demographic") {
           out <- process_open_ended(surv_obj, question)
         }
         if (family == "datetime") {

--- a/R/response_parsers.R
+++ b/R/response_parsers.R
@@ -30,6 +30,12 @@ process_matrix <- function(surv_obj, question) {
         answer_text = TRUE
       out_named[[question_text]] <- answer_text
       out_id[[col_id]] <- answer_text
+    } else if (subtype == 'menu') {
+          question_text = paste0(surv_obj$questions[[question_id]], " - ", surv_obj$answers[[answer$row_id]], " - ", surv_obj$answers[[answer$col_id]])
+          col_id = paste0(question_id, "_", answer$row_id, "_", answer$col_id)
+          answer_text = surv_obj$answers[[answer$choice_id]]
+          out_named[[question_text]] <- answer_text
+          out_id[[col_id]] <- answer_text
     } else {
       question_text = paste0(surv_obj$questions[[question_id]], " - ", surv_obj$answers[[answer$row_id]])
       col_id = paste0(question_id, "_", answer$row_id)


### PR DESCRIPTION
Updated the code to include the the 'matrix of drop-down menus' answers available in GitHub. 
In order to make it work, two additional changes were made: 
- (i) I include a nested loop in fetch_survey.R to capture by each column the choices (capture column name in answers and drop-down choices in answers and choices). 
- (ii) changed process_matrix function in response_parsers.R to include the 'menu' subtype. In this type, the name of the column is a combination of three variables: question_id, row_id and col_id.